### PR TITLE
Remove stray prompt text from script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -2131,4 +2131,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Update calls to the renamed function (This block seems like a remnant, ensure selectElement is fully removed or adapted)
-}); 
+});


### PR DESCRIPTION
## Summary
- clean up trailing text left from command prompt
- ensure `script.js` ends with a newline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b2a3c058832698396edc373d918f