### PR TITLE
Fix action bar group button display

### DIFF
--- a/script.js
+++ b/script.js
@@ -2200,9 +2200,11 @@ document.addEventListener('DOMContentLoaded', () => {
         // Show/hide and update group button based on selection
         const groupBtn = actionBar ? actionBar.querySelector('[data-action="group"]') : null;
         if (groupBtn) {
-            const hasGroupedElements = $selected.toArray().some(el => $(el).attr('data-group-id'));
-            const allSameGroup = $selected.length > 1 && 
-                               $selected.toArray().every(el => $(el).attr('data-group-id') === $($selected[0]).attr('data-group-id'));
+            const groupIds = $selected.toArray().map(el => $(el).attr('data-group-id'));
+            const hasGroupedElements = groupIds.some(id => id);
+            const allHaveGroup = groupIds.length > 0 && groupIds.every(id => id);
+            const firstGroupId = groupIds[0];
+            const allSameGroup = allHaveGroup && groupIds.every(id => id === firstGroupId);
             
             console.log('Action bar update:', {
                 selectedCount: $selected.length,
@@ -2211,22 +2213,26 @@ document.addEventListener('DOMContentLoaded', () => {
                 firstElementGroupId: $selected.length > 0 ? $($selected[0]).attr('data-group-id') : null
             });
             
-            if ($selected.length > 1 && !allSameGroup) {
-                // Multiple elements not in same group - show "Group" button
+            if ($selected.length > 1) {
                 groupBtn.style.display = 'flex';
-                groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
-                groupBtn.title = 'Group';
-                groupBtn.setAttribute('data-action', 'group');
-                console.log('Showing GROUP button');
+                if (allSameGroup) {
+                    groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
+                    groupBtn.title = 'Ungroup';
+                    groupBtn.setAttribute('data-action', 'ungroup');
+                    console.log('Showing UNGROUP button');
+                } else {
+                    groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
+                    groupBtn.title = 'Group';
+                    groupBtn.setAttribute('data-action', 'group');
+                    console.log('Showing GROUP button');
+                }
             } else if (hasGroupedElements) {
-                // Has grouped elements - show "Ungroup" button
                 groupBtn.style.display = 'flex';
                 groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
                 groupBtn.title = 'Ungroup';
                 groupBtn.setAttribute('data-action', 'ungroup');
                 console.log('Showing UNGROUP button');
             } else {
-                // Single element or no groups - hide button
                 groupBtn.style.display = 'none';
                 console.log('Hiding group button');
             }


### PR DESCRIPTION
## Summary
- correct logic for showing the group/ungroup button
- show the action bar's group option when multiple items are selected

## Testing
- `python3 combine_html.py`

------
https://chatgpt.com/codex/tasks/task_e_6846adb39fa48326b098f3d3149bfbae