### PR TITLE
Fix action bar visibility during movement

### DIFF
--- a/script.js
+++ b/script.js
@@ -2325,7 +2325,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Update action bar and group outline on selection changes
     $(document).on('selectionChanged', function() {
         setTimeout(() => {
-            showActionBar();
+            if (!$('body').hasClass('dragging-active') && !resizing) {
+                showActionBar();
+            }
             updateGroupOutline(); // Show group outline for multiple selections
         }, 50); // Increased delay to ensure elements are fully rendered
     });


### PR DESCRIPTION
## Summary
- avoid showing the action bar while dragging elements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846ad9217c08326b61c55972d6fb643