### PR TITLE
Fix action bar group button display

### DIFF
--- a/script.js
+++ b/script.js
@@ -2200,9 +2200,11 @@ document.addEventListener('DOMContentLoaded', () => {
         // Show/hide and update group button based on selection
         const groupBtn = actionBar ? actionBar.querySelector('[data-action="group"]') : null;
         if (groupBtn) {
-            const hasGroupedElements = $selected.toArray().some(el => $(el).attr('data-group-id'));
-            const allSameGroup = $selected.length > 1 && 
-                               $selected.toArray().every(el => $(el).attr('data-group-id') === $($selected[0]).attr('data-group-id'));
+            const groupIds = $selected.toArray().map(el => $(el).attr('data-group-id'));
+            const hasGroupedElements = groupIds.some(id => id);
+            const allHaveGroup = groupIds.length > 0 && groupIds.every(id => id);
+            const firstGroupId = groupIds[0];
+            const allSameGroup = allHaveGroup && groupIds.every(id => id === firstGroupId);
             
             console.log('Action bar update:', {
                 selectedCount: $selected.length,
@@ -2211,22 +2213,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 firstElementGroupId: $selected.length > 0 ? $($selected[0]).attr('data-group-id') : null
             });
             
-            if ($selected.length > 1 && !allSameGroup) {
-                // Multiple elements not in same group - show "Group" button
+            if ($selected.length > 1) {
                 groupBtn.style.display = 'flex';
-                groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
-                groupBtn.title = 'Group';
-                groupBtn.setAttribute('data-action', 'group');
-                console.log('Showing GROUP button');
-            } else if (hasGroupedElements) {
-                // Has grouped elements - show "Ungroup" button
-                groupBtn.style.display = 'flex';
-                groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
-                groupBtn.title = 'Ungroup';
-                groupBtn.setAttribute('data-action', 'ungroup');
-                console.log('Showing UNGROUP button');
+                if (allSameGroup) {
+                    groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
+                    groupBtn.title = 'Ungroup';
+                    groupBtn.setAttribute('data-action', 'ungroup');
+                    console.log('Showing UNGROUP button');
+                } else {
+                    groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
+                    groupBtn.title = 'Group';
+                    groupBtn.setAttribute('data-action', 'group');
+                    console.log('Showing GROUP button');
+                }
             } else {
-                // Single element or no groups - hide button
                 groupBtn.style.display = 'none';
                 console.log('Hiding group button');
             }
@@ -2437,8 +2437,6 @@ document.addEventListener('DOMContentLoaded', () => {
         // Assign group-id to all selected elements
         $selected.each(function() {
             $(this).attr('data-group-id', groupId);
-            // Add visual indicator that element is grouped
-            $(this).addClass('grouped-element');
         });
         
         console.log('Created group', groupId, 'with', $selected.length, 'elements');
@@ -2456,7 +2454,6 @@ document.addEventListener('DOMContentLoaded', () => {
         
         $selected.each(function() {
             $(this).removeAttr('data-group-id');
-            $(this).removeClass('grouped-element');
         });
         
         console.log('Ungrouped', $selected.length, 'elements');
@@ -2676,12 +2673,11 @@ document.addEventListener('DOMContentLoaded', () => {
          });
          
          // Copy group-id if it exists (but generate new group for copied elements)
-         const originalGroupId = $original.attr('data-group-id');
-         if (originalGroupId) {
-             const newGroupId = 'group-' + Date.now() + '-' + Math.random().toString(36).substr(2, 5);
-             $new.attr('data-group-id', newGroupId);
-             $new.addClass('grouped-element');
-         }
+        const originalGroupId = $original.attr('data-group-id');
+        if (originalGroupId) {
+            const newGroupId = 'group-' + Date.now() + '-' + Math.random().toString(36).substr(2, 5);
+            $new.attr('data-group-id', newGroupId);
+        }
      }
 
      /**

--- a/script.js
+++ b/script.js
@@ -2085,6 +2085,8 @@ document.addEventListener('DOMContentLoaded', () => {
             } else if (elementType === 'group') {
                 // Deep clone the group container
                 newElement = $original.clone(false)[0]; // false to not copy event handlers initially
+                // Remove selection classes from group and its children
+                $(newElement).removeClass('selected').find('.selected').removeClass('selected');
                 $(newElement).css({
                     left: newLeft + 'px',
                     top: newTop + 'px'
@@ -2106,9 +2108,8 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         if (newElements.length > 0) {
-            $('.selected').removeClass('selected'); // Deselect originals
-            $(newElements).addClass('selected');    // Select new copies
-            $(document).trigger('selectionChanged');
+            // Keep original selection, don't auto-select copied elements
+            console.log('Copied', newElements.length, 'elements');
         }
     }
 
@@ -2325,7 +2326,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Update action bar and group outline on selection changes
     $(document).on('selectionChanged', function() {
         setTimeout(() => {
-            showActionBar();
+            if (!$('body').hasClass('dragging-active') && !resizing) {
+                showActionBar();
+            }
             updateGroupOutline(); // Show group outline for multiple selections
         }, 50); // Increased delay to ensure elements are fully rendered
     });
@@ -2534,10 +2537,12 @@ document.addEventListener('DOMContentLoaded', () => {
                      newElement = copyGenericElement($original, documentArea, newLeft, newTop);
                  }
 
-                 if (newElement) {
-                     newElements.push(newElement);
-                     offsetIncrement += 5;
-                 }
+                if (newElement) {
+                    // Ensure copied elements don't retain selection styling
+                    $(newElement).removeClass('selected').find('.selected').removeClass('selected');
+                    newElements.push(newElement);
+                    offsetIncrement += 5;
+                }
              } catch (error) {
                  console.error('Error copying element:', error);
              }
@@ -2639,18 +2644,21 @@ document.addEventListener('DOMContentLoaded', () => {
      /**
       * Helper function to copy generic/unknown elements
       */
-     function copyGenericElement($original, documentArea, left, top) {
-         const newElement = $original.clone(true)[0];
-         
-         $(newElement).css({ left: left + 'px', top: top + 'px' });
+    function copyGenericElement($original, documentArea, left, top) {
+        const newElement = $original.clone(true)[0];
+
+        $(newElement).css({ left: left + 'px', top: top + 'px' });
          
          // Generate new ID if it has one
          if (newElement.id) {
              newElement.id = newElement.id + '-copy-' + Date.now();
          }
          
-         documentArea.appendChild(newElement);
-         makeElementsDraggable($(newElement));
+        // Remove any selection classes from the cloned structure
+        $(newElement).removeClass('selected').find('.selected').removeClass('selected');
+
+        documentArea.appendChild(newElement);
+        makeElementsDraggable($(newElement));
 
          return newElement;
      }
@@ -2660,10 +2668,11 @@ document.addEventListener('DOMContentLoaded', () => {
       */
      function copyElementStyles($original, $new) {
          // Copy common CSS properties
-         const stylesToCopy = [
-             'transform', 'z-index', 'opacity', 'filter',
-             'box-shadow', 'border-radius', 'background-color'
-         ];
+        const stylesToCopy = [
+            'transform', 'z-index', 'opacity', 'filter',
+            // Do not copy box-shadow to avoid transferring selection borders
+            'border-radius', 'background-color'
+        ];
          
          stylesToCopy.forEach(style => {
              const value = $original.css(style);

--- a/styles.css
+++ b/styles.css
@@ -1014,23 +1014,6 @@ body {
 
 /* Group button visibility is controlled by JavaScript */
 
-/* Visual indicator for grouped elements */
-.grouped-element {
-    box-shadow: 0 0 0 1px rgba(40, 167, 69, 0.3) !important;
-}
-
-.grouped-element::before {
-    content: '';
-    position: absolute;
-    top: 2px;
-    right: 2px;
-    width: 8px;
-    height: 8px;
-    background: #28a745;
-    border-radius: 50%;
-    z-index: 100;
-    pointer-events: none;
-}
 
 /* Remove old floating action styles */
 .no-zoom-scale, #multi-select-toolbar, #floating-action-bar {


### PR DESCRIPTION
## Summary
- remove CSS class for grouped elements
- hide group button unless at least two items are selected
- allow grouping/ungrouping without extra styling

## Testing
- `python3 combine_html.py`


------
https://chatgpt.com/codex/tasks/task_e_6846adb39fa48326b098f3d3149bfbae