### PR TITLE
Implement conditional group/ungroup button

### DIFF
--- a/script.js
+++ b/script.js
@@ -2202,32 +2202,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const groupBtn = actionBar ? actionBar.querySelector('[data-action="group"]') : null;
         if (groupBtn) {
             const groupIds = $selected.toArray().map(el => $(el).attr('data-group-id'));
-            const hasGroupedElements = groupIds.some(id => id);
             const allHaveGroup = groupIds.length > 0 && groupIds.every(id => id);
             const firstGroupId = groupIds[0];
             const allSameGroup = allHaveGroup && groupIds.every(id => id === firstGroupId);
-            
+
             console.log('Action bar update:', {
                 selectedCount: $selected.length,
-                hasGroupedElements,
-                allSameGroup,
-                firstElementGroupId: $selected.length > 0 ? $($selected[0]).attr('data-group-id') : null
+                allSameGroup
             });
-            
+
             if ($selected.length > 1) {
-                groupBtn.style.display = 'flex';
-                if (allSameGroup) {
-                    groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
-                    groupBtn.title = 'Ungroup';
-                    groupBtn.setAttribute('data-action', 'ungroup');
-                    console.log('Showing UNGROUP button');
-                } else {
-                    groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
-                    groupBtn.title = 'Group';
-                    groupBtn.setAttribute('data-action', 'group');
-                    console.log('Showing GROUP button');
-                }
-            } else if (hasGroupedElements) {
                 groupBtn.style.display = 'flex';
                 if (allSameGroup) {
                     groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';


### PR DESCRIPTION
## Summary
- hide grouping button when only one item is selected
- continue toggling button between group and ungroup when multiple items selected

## Testing
- `node --check script.js`
- `python3 -m py_compile combine_html.py`


------
https://chatgpt.com/codex/tasks/task_e_6846b434a8d48326b3fc78c818005605