### PR TITLE
Fix action bar group button logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,8 +132,11 @@
 
     <!-- Universal Floating Action Bar -->
     <div id="universal-action-bar" class="action-bar-hidden">
-        <div class="action-btn" data-action="group" title="Group" style="display: none;">
+        <div id="group-btn" class="action-btn" data-action="group" title="Group" style="display: none;">
             <i class="fas fa-object-group"></i>
+        </div>
+        <div id="ungroup-btn" class="action-btn" data-action="ungroup" title="Ungroup" style="display: none;">
+            <i class="fas fa-object-ungroup"></i>
         </div>
         <div class="action-btn" data-action="copy" title="Copy">
             <i class="fas fa-copy"></i>

--- a/script.js
+++ b/script.js
@@ -2199,53 +2199,37 @@ document.addEventListener('DOMContentLoaded', () => {
         console.log('showActionBar called with', $selected.length, 'selected elements');
 
         // Show/hide and update group button based on selection
-        const groupBtn = actionBar ? actionBar.querySelector('[data-action="group"]') : null;
-        if (groupBtn) {
+        const groupBtn = actionBar ? document.getElementById('group-btn') : null;
+        const ungroupBtn = actionBar ? document.getElementById('ungroup-btn') : null;
+
+        if (groupBtn && ungroupBtn) {
             const groupIds = $selected.toArray().map(el => $(el).attr('data-group-id'));
-            const hasGroupedElements = groupIds.some(id => id);
             const allHaveGroup = groupIds.length > 0 && groupIds.every(id => id);
             const firstGroupId = groupIds[0];
             const allSameGroup = allHaveGroup && groupIds.every(id => id === firstGroupId);
-            
+
             console.log('Action bar update:', {
                 selectedCount: $selected.length,
-                hasGroupedElements,
-                allSameGroup,
-                firstElementGroupId: $selected.length > 0 ? $($selected[0]).attr('data-group-id') : null
+                allSameGroup
             });
-            
+
             if ($selected.length > 1) {
-                groupBtn.style.display = 'flex';
                 if (allSameGroup) {
-                    groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
-                    groupBtn.title = 'Ungroup';
-                    groupBtn.setAttribute('data-action', 'ungroup');
+                    groupBtn.style.display = 'none';
+                    ungroupBtn.style.display = 'flex';
                     console.log('Showing UNGROUP button');
                 } else {
-                    groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
-                    groupBtn.title = 'Group';
-                    groupBtn.setAttribute('data-action', 'group');
-                    console.log('Showing GROUP button');
-                }
-            } else if (hasGroupedElements) {
-                groupBtn.style.display = 'flex';
-                if (allSameGroup) {
-                    groupBtn.innerHTML = '<i class="fas fa-object-ungroup"></i>';
-                    groupBtn.title = 'Ungroup';
-                    groupBtn.setAttribute('data-action', 'ungroup');
-                    console.log('Showing UNGROUP button');
-                } else {
-                    groupBtn.innerHTML = '<i class="fas fa-object-group"></i>';
-                    groupBtn.title = 'Group';
-                    groupBtn.setAttribute('data-action', 'group');
+                    groupBtn.style.display = 'flex';
+                    ungroupBtn.style.display = 'none';
                     console.log('Showing GROUP button');
                 }
             } else {
                 groupBtn.style.display = 'none';
-                console.log('Hiding group button');
+                ungroupBtn.style.display = 'none';
+                console.log('Hiding group and ungroup buttons');
             }
         } else {
-            console.warn('Group button not found in action bar');
+            console.warn('Group or ungroup button not found in action bar');
         }
 
         // Position the bar


### PR DESCRIPTION
## Summary
- keep separate group and ungroup buttons
- ensure only one of them is shown when multiple elements are selected

## Testing
- `node --check script.js`
- `python3 -m py_compile combine_html.py`


------
https://chatgpt.com/codex/tasks/task_e_6846b434a8d48326b3fc78c818005605