### PR TITLE
Add universal resizing logic

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1027,7 +1027,7 @@ body {
     background: rgba(225, 6, 0, 0.08);
     border-radius: 6px;
     z-index: 25;
-    pointer-events: none;
+    pointer-events: auto; /* allow interactions for resizing */
     display: none;
 }
 


### PR DESCRIPTION
## Summary
- enable pointer events on group selection outline
- add helper functions for detecting resize direction and mapping cursors
- implement universal resize logic that works for multiple selected elements
- show resize cursors when hovering selected elements or the group outline

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846bc3a30948326a0c8a97b9a858817