### PR TITLE
Custom drag handling for selected elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A modern web application for creating documents with drag-and-drop functionality
 
 - Built with vanilla JavaScript, HTML5, and CSS3
 - Uses the HTML5 Drag and Drop API
-- jQuery UI provides enhanced drag-and-drop interactions
+- Custom JavaScript handles drag-and-drop interactions for selected elements
 - html2canvas and jsPDF power the export to PDF feature
 - Responsive design that works on different screen sizes
 - Font Awesome provides icons

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
     <link rel="stylesheet" href="styles.css">
     <!-- Include Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <!-- jQuery UI -->
-    <link rel="stylesheet" href="https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css">
     <!-- jsPDF and html2canvas for PDF generation -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
@@ -221,7 +219,5 @@
 
     <!-- Include jQuery -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <!-- Include jQuery UI -->
-    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
 </body>
 </html> 


### PR DESCRIPTION
## Summary
- drop jQuery UI from the page
- rewrite dragging logic to move all selected items together
- keep a no-op `makeElementsDraggable` for compatibility
- update README to mention the new drag implementation
- clean up outdated drag comments

## Testing
- `python combine_html.py`


------
https://chatgpt.com/codex/tasks/task_e_6846ce30a7348326a1c0243eb80be380